### PR TITLE
Disable husky causing CI build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "test": "ember test",
     "semantic-release": "semantic-release",
     "prepublishOnly": "ember ts:precompile",
-    "postpublish": "ember ts:clean",
-    "prepare": "husky install"
+    "postpublish": "ember ts:clean"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
When ember-api-actions is included in devDependecies of a project the
project fails to build. Unsure how to fix and still install husky, this PR disables husky install.

Running `rm -rf node_modules .yarn; yarn --cache-folder .yarn` and
husky install fails with the following error

[5/5] Building fresh packages...
$ husky install
/builds/qonto/qonto-js/.yarn/v6/.tmp/b6d4db6359a1bf393ecc6b39b29d5e06.09e647d8426d11943760a8ee0cb058c5ddb949e6.prepare/node_modules/husky/lib/index.js:20
        throw new Error(`.git can't be found (see ${url})`);
        ^
Error: .git can't be found (see https://typicode.github.io/husky/#/?id=custom-directory)
    at Object.install (/builds/qonto/qonto-js/.yarn/v6/.tmp/b6d4db6359a1bf393ecc6b39b29d5e06.09e647d8426d11943760a8ee0cb058c5ddb949e6.prepare/node_modules/husky/lib/index.js:20:15)
    at Object.install (/builds/qonto/qonto-js/.yarn/v6/.tmp/b6d4db6359a1bf393ecc6b39b29d5e06.09e647d8426d11943760a8ee0cb058c5ddb949e6.prepare/node_modules/husky/lib/bin.js:27:41)
    at Object.<anonymous> (/builds/qonto/qonto-js/.yarn/v6/.tmp/b6d4db6359a1bf393ecc6b39b29d5e06.09e647d8426d11943760a8ee0cb058c5ddb949e6.prepare/node_modules/husky/lib/bin.js:39:22)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47